### PR TITLE
Do not use assertions to check arguments

### DIFF
--- a/recursive_monkey_patch.py
+++ b/recursive_monkey_patch.py
@@ -213,7 +213,8 @@ def monkey_patch(source, target, log_level=logging.WARNING, logger=None):
     logger.debug("Monkey patching {} into {}".format(source.__name__, target.__name__))
 
     if isinstance(source, ModuleType):
-        assert isinstance(target, ModuleType)
+        if not isinstance(target, ModuleType):
+            raise TypeError("target must be a module but %r is a %s"%(target, type(target)))
         if hasattr(source, "__path__"):
             # Force loading all submodules
             for (module_loader, name, ispkg) in pkgutil.iter_modules(path=source.__path__):
@@ -245,7 +246,8 @@ def monkey_patch(source, target, log_level=logging.WARNING, logger=None):
             except ImportError:
                 pass
             else:
-                assert isinstance(subtarget, (type, ModuleType))
+                if not isinstance(subtarget, (type, ModuleType)):
+                    raise TypeError("%s.%s must be a module but it is a %s"%(target.__name__, key, type(subtarget)))
                 logger.debug("Recursing into preexisting submodule of the target")
                 monkey_patch(subsource, subtarget, logger=logger)
                 continue
@@ -253,7 +255,8 @@ def monkey_patch(source, target, log_level=logging.WARNING, logger=None):
         if isinstance(subsource, (type, TypeType)) and key in target.__dict__:
             # Recurse into a class which already exists in the target
             subtarget = target.__dict__[key]
-            assert isinstance(subtarget, (type, TypeType))
+            if not isinstance(subtarget, (type, TypeType)):
+                raise TypeError("expected '%s' to be a type in the target but it is a %s"%(key, type(subtarget)))
             monkey_patch(subsource, subtarget, logger=logger)
             continue
 


### PR DESCRIPTION
I think it's nicer to use actual exceptions (that can not be disabled by
setting PYTHON_OPTIMIZE) with proper error messages explaining what's the
issue.